### PR TITLE
[APInt] add `clearBits` and partial `insertBits`

### DIFF
--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -7126,23 +7126,11 @@ struct BitCastBuffer {
   inline static void copyBitsFrom(APInt &LHS, const BitSlice &Dst,
                                   const APInt &RHS, const BitSlice &Src) {
     assert(Src.size() == Dst.size());
-
-    if (Src.start() > 0 || Src.end() < RHS.getBitWidth() ||
-        RHS.getBitWidth() != Dst.size()) {
-      APInt Val = RHS.lshr(Src.start()).trunc(Src.size()).zext(Dst.size());
-      LHS.insertBits(Val, Dst.start());
-      return;
-    }
-    LHS.insertBits(RHS, Dst.start());
+    LHS.insertBits(RHS, Src.start(), Dst.start(), Src.size());
   }
 
   inline static void clearBits(APInt &Int, const BitSlice &Which) {
-    unsigned Bit = Which.start(), Rem = Which.size() % 64;
-    if (Rem > 0) // else APInt crashes when Bit == 0
-      Int.insertBits(0ull, Bit, Rem);
-    Bit += Rem;
-    for (unsigned End = Which.end(); Bit < End; Bit += 64)
-      Int.insertBits(0ull, Bit, 64u);
+    Int.clearBits(Which.start(), Which.end());
   }
 
   static llvm::FormattedBytes formatInt(const APInt &Int) {


### PR DESCRIPTION
Introduces `APInt::clearBits(loBit, hiBit)` and a more general `APInt::insertBits(...)` overload that allows copying from a subrange of a source APInt. Reworks the implementation of `insertBits` to use the more general form, and removes the bit-by-bit copying fallback in favor of a strategy that works by conditionally aligning the copy to byte boundaries and then using `memcpy`.

`APInt::clearBits(...)` works similarly, aligning the mask when necessary and then using `memset` to batch-clear a sequence of bytes. Previously, the best option was to use `insertBits(uint64_t, ...)` in a loop, as the removed code demonstrates.

Makes use of these new capabilities from constant expression's BitCastBuffer that commonly needs to copy/clear unaligned or partial segments.

Adds tests for new functionality, and updates some old `APInt::insertBits` tests that seemed like they were intended to make use of the `uint64_t` overload instead of copying from another `APInt` object.

Finally, after this commit, the wording of the parameter description for `hiBit` on `APInt::getBitSet` lines up with the implementation. The previous phrasing seemed to indicate that `APInt::getBitSet(N, 0, N-1)` would set all the bits in the int, but it's `APInt::getBitSet(N, 0, N)` that produces that result.